### PR TITLE
feat: dual size(apparent, allocated) metrics and UI updates

### DIFF
--- a/cursor-history/cursor_history_6.md
+++ b/cursor-history/cursor_history_6.md
@@ -1,0 +1,41 @@
+# TreeSize-rs Chat Session Summary
+
+## Modifications to Disk Space Analysis Tool
+
+### 1. Return Both Apparent Size and Allocated Size
+
+- Modified platform.rs to always return both apparent size and allocated size
+- Removed the `use_apparent_size` parameter, which previously made the function return only one type of size
+- Updated function signatures to return both size metrics simultaneously
+- Ensured proper handling of both size types on Windows and Unix platforms
+
+### 2. Counting Allocated Size in Directory Hierarchies
+
+- Added initialization of `size_allocated_bytes` in the AnalyticsInfo struct
+- Implemented tracking of allocated size in parallel directory scanning
+- Updated directory size calculations to account for both apparent and allocated sizes
+- Ensured proper aggregation of allocated sizes up the directory tree
+
+### 3. Refactoring Size Field Names for Consistency
+
+- Renamed fields from `size` to `size_bytes` and `size_allocated` to `size_allocated_bytes`
+- Updated all references to these fields throughout the codebase
+- Created consistent naming pattern across platform-specific and UI components
+
+### 4. UI Implementation of Allocated Size Column
+
+- Added "Allocated" column to the TreeSizeView component
+- Updated grid layout to accommodate the new column
+- Ensured proper display and formatting of allocated size values
+- Fixed grid columns in both rows and headers
+
+## Purpose
+
+These changes enable users to see both the apparent size (logical file size) and allocated size (actual disk space used) separately. This is particularly useful for:
+
+- Identifying compression efficiency
+- Finding sparse files
+- Understanding actual disk usage versus logical file sizes
+- Better analysis of storage patterns
+
+The UI now clearly displays both metrics side by side for easy comparison.

--- a/src/components/DirectoryScanner.tsx
+++ b/src/components/DirectoryScanner.tsx
@@ -54,6 +54,7 @@ interface FileSystemTreeNode {
   path: string
   name: string
   size_bytes: number
+  size_allocated_bytes: number
   entry_count: number
   file_count: number
   directory_count: number
@@ -323,7 +324,7 @@ export function DirectoryScanner() {
       type: node.directory_count > 0 ? "directory" : "file",
       sizeBytes: node.size_bytes,
       entryCount: node.entry_count,
-      allocatedBytes: node.size_bytes, // Use size_bytes as allocatedBytes
+      allocatedBytes: node.size_allocated_bytes,
       fileCount: node.file_count,
       folderCount: node.directory_count,
       percentOfParent: node.percent_of_parent,
@@ -758,7 +759,7 @@ function TreeSizeView({
         style={style}
         className="border-b hover:bg-muted/30 transition-colors"
       >
-        <div className="grid grid-cols-[auto_1fr_repeat(6,auto)] text-sm h-full">
+        <div className="grid grid-cols-[auto_1fr_repeat(7,auto)] text-sm h-full">
           {/* Expand/collapse button with proper indentation */}
           <div
             className="p-1 flex items-center justify-center cursor-pointer"
@@ -810,6 +811,11 @@ function TreeSizeView({
             {formatSize(item.sizeBytes)}
           </div>
 
+          {/* Always show allocated size */}
+          <div className="p-2 text-right font-mono w-24">
+            {formatSize(item.allocatedBytes)}
+          </div>
+
           {/* Always show percent of parent */}
           <div
             className={`p-2 text-right font-mono w-24 ${
@@ -839,10 +845,11 @@ function TreeSizeView({
   return (
     <div className="h-full flex flex-col">
       {/* Header - Sticky */}
-      <div className="grid grid-cols-[auto_1fr_repeat(6,auto)] sticky top-0 bg-muted/90 text-sm font-medium border-b select-none z-10 shadow-sm flex-shrink-0">
+      <div className="grid grid-cols-[auto_1fr_repeat(7,auto)] sticky top-0 bg-muted/90 text-sm font-medium border-b select-none z-10 shadow-sm flex-shrink-0">
         <div className="w-6"></div>
         <div className="p-2">Name</div>
         <div className="p-2 text-right w-24">Size</div>
+        <div className="p-2 text-right w-24">Allocated</div>
         <div className="p-2 text-right w-24">% of Parent</div>
         <div className="p-2 text-right w-16">Files</div>
         <div className="p-2 text-right w-16">Folders</div>


### PR DESCRIPTION
- Introduced functionality to return both apparent size and allocated size in the disk space analysis tool.
- Updated the AnalyticsInfo struct and related calculations to track allocated sizes in directory hierarchies.
- Refactored size field names for consistency across the codebase.
- Added a new "Allocated" column in the TreeSizeView component for improved UI display of size metrics.
- Enhanced user experience by allowing easy comparison of logical and actual disk usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The Disk Space Analysis tool now displays both apparent and allocated file sizes, offering a more comprehensive view of storage usage.
  
- **Refactor**
  - Enhanced size calculations and data aggregation ensure more accurate reporting of disk usage.
  
- **Style**
  - Updated the directory view with a dedicated "Allocated" column and refined grid layout for improved visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->