### PR TITLE
feat: Add owner name tracking to file system entries

### DIFF
--- a/cursor-history/cursor_history_8.md
+++ b/cursor-history/cursor_history_8.md
@@ -39,3 +39,38 @@ In this session, we implemented file owner information support throughout the ap
   - Platform limitations
 
 - The implementation handles cross-platform compatibility while providing platform-specific optimizations.
+
+## Windows Owner Name Fix:
+
+The initial Windows implementation had a limitation where it only accepted `SidTypeUser` as a valid owner type. However, Windows files can be owned by various security principal types. The fix involved:
+
+1. **Extended SID Type Support**:
+   - Added support for multiple SID types:
+     - `SidTypeUser` (1): Regular user accounts
+     - `SidTypeWellKnownGroup` (2): Built-in groups like "Administrators"
+     - `SidTypeAlias` (4): Local group accounts
+     - `SidTypeDeletedAccount` (6): Deleted accounts
+
+2. **Improved Error Handling**:
+   - Added detailed error logging at each potential failure point
+   - Added specific handling for deleted accounts
+   - Better error messages for debugging ownership issues
+
+3. **Key Code Changes**:
+   ```rust
+   match sid_type {
+     t if t == SidTypeUser || t == SidTypeWellKnownGroup || t == SidTypeAlias => {
+       // Accept users, well-known groups, and local groups as valid owners
+       // Convert name and return
+     }
+     t if t == SidTypeDeletedAccount => {
+       Some("<deleted account>".to_string())
+     }
+     _ => {
+       eprintln!("Unsupported SID type: {}", sid_type);
+       None
+     }
+   }
+   ```
+
+This fix ensures proper owner name resolution on Windows, handling the full range of possible file owners in the Windows security model.

--- a/cursor-history/cursor_history_8.md
+++ b/cursor-history/cursor_history_8.md
@@ -1,0 +1,41 @@
+# File Owner Information Implementation
+
+In this session, we implemented file owner information support throughout the application. This feature allows users to see who owns each file and directory in the tree view.
+
+## Changes Made:
+
+1. **Platform-Specific Owner Name Implementation**:
+   - Added `owner_name: Option<String>` to the `PathInfo` struct in `platform.rs`
+   - Implemented Unix owner retrieval using the `users` crate which maps UIDs to usernames
+   - Implemented Windows owner retrieval using WinAPI (GetNamedSecurityInfoW, LookupAccountSidW)
+   - Added fallback implementation for other platforms
+
+2. **Updated Cargo Dependencies**:
+   - Added `users = "0.11"` for Unix platforms
+   - Extended winapi to include security features: `winapi = { version = "0.3", features = ["winnt", "securitybaseapi", "accctrl", "aclapi", "sddl"] }`
+
+3. **Data Structure Integration**:
+   - Added `owner_name` to `FileSystemEntry` struct
+   - Added `owner_name` to `FileSystemTreeNode` struct
+   - Added `owner_name` to `AnalyticsInfo` struct
+   - Updated `analytics_map_to_entries` and tree building functions to preserve owner information
+
+4. **UI Integration**:
+   - Updated TypeScript `FileSystemTreeNode` interface to include `owner_name: string | null`
+   - Modified `convertTreeNodeToTreeViewItem` to display owner information: `owner: node.owner_name || "Unknown"`
+   - Owner name now appears as a column in the directory tree view
+
+5. **Unit Testing**:
+   - Added `test_owner_name_unix` to verify Unix owner detection
+   - Added `test_owner_name_windows` to verify Windows owner detection
+   - Tests verify both direct path info and end-to-end analytics propagation
+
+## Design Considerations:
+
+- Used `Option<String>` for owner name since it might not be available in some cases:
+  - Permission issues
+  - Missing users
+  - Special filesystems
+  - Platform limitations
+
+- The implementation handles cross-platform compatibility while providing platform-specific optimizations.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3148,9 +3148,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.14"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e327e510263980e231de548a33e63d34962d29ae61b467389a1a09627a254"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4504,6 +4504,8 @@ dependencies = [
  "tauri-plugin-shell",
  "tempfile",
  "tokio",
+ "users",
+ "winapi",
  "winapi-util",
 ]
 
@@ -4617,6 +4619,16 @@ dependencies = [
  "serde",
  "unic-ucd-ident",
  "url",
+]
+
+[[package]]
+name = "users"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24cc0f6d6f267b73e5a2cadf007ba8f9bc39c6a6f9666f8cf25ea809a153b032"
+dependencies = [
+ "libc",
+ "log",
 ]
 
 [[package]]
@@ -4983,11 +4995,11 @@ dependencies = [
 
 [[package]]
 name = "windows-collections"
-version = "0.1.2"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b095389c0f7a1e16ba4927c17478dca870938c7bbeb31e7f77eab4e86dc8fd1a"
+checksum = "5467f79cc1ba3f52ebb2ed41dbb459b8e7db636cc3429458d9a852e15bc24dec"
 dependencies = [
- "windows-core 0.61.0",
+ "windows-core 0.60.1",
 ]
 
 [[package]]
@@ -5021,29 +5033,16 @@ dependencies = [
  "windows-interface 0.59.1",
  "windows-link",
  "windows-result 0.3.2",
- "windows-strings 0.3.1",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
-dependencies = [
- "windows-implement 0.60.0",
- "windows-interface 0.59.1",
- "windows-link",
- "windows-result 0.3.2",
- "windows-strings 0.4.0",
+ "windows-strings",
 ]
 
 [[package]]
 name = "windows-future"
-version = "0.1.2"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb86813135724d122c524095d1e55a72f2844b0ce6b77ef05e782dff1e6abfc"
+checksum = "a787db4595e7eb80239b74ce8babfb1363d8e343ab072f2ffe901400c03349f0"
 dependencies = [
- "windows-core 0.61.0",
+ "windows-core 0.60.1",
  "windows-link",
 ]
 
@@ -5063,17 +5062,6 @@ name = "windows-implement"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5125,7 +5113,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
  "windows-result 0.3.2",
- "windows-strings 0.3.1",
+ "windows-strings",
  "windows-targets 0.53.0",
 ]
 
@@ -5152,15 +5140,6 @@ name = "windows-strings"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
 dependencies = [
  "windows-link",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -42,9 +42,13 @@ rayon = "1"
 dirs = "6"
 lazy_static = "1"
 
+[target.'cfg(unix)'.dependencies]
+users = "0.11"
+
 [target.'cfg(windows)'.dependencies]
 winapi-util = "0.1"
 filesize = "0.2.0"
+winapi = { version = "0.3", features = ["winnt", "securitybaseapi", "accctrl", "aclapi", "sddl"] }
 
 [dev-dependencies]
 tempfile = "3.10.1"

--- a/src-tauri/src/platform.rs
+++ b/src-tauri/src/platform.rs
@@ -338,6 +338,7 @@ fn get_owner_name<P: AsRef<Path>>(path: P, _metadata: &std::fs::Metadata) -> Opt
   use winapi::shared::winerror::ERROR_SUCCESS;
   use winapi::um::securitybaseapi::GetSecurityDescriptorOwner;
   use winapi::um::winbase::LocalFree;
+  use winapi::ctypes::c_void;
   
   let path = path.as_ref();
   let path_wide: Vec<u16> = path.as_os_str().encode_wide().chain(std::iter::once(0)).collect();
@@ -363,7 +364,7 @@ fn get_owner_name<P: AsRef<Path>>(path: P, _metadata: &std::fs::Metadata) -> Opt
     }
 
     // Ensure proper cleanup of security descriptor
-    struct SdCleanup(*mut std::ffi::c_void);
+    struct SdCleanup(*mut c_void);
     impl Drop for SdCleanup {
       fn drop(&mut self) {
         unsafe { LocalFree(self.0) };

--- a/src-tauri/src/platform.rs
+++ b/src-tauri/src/platform.rs
@@ -322,7 +322,10 @@ fn get_owner_name<P: AsRef<Path>>(_path: P, metadata: &std::fs::Metadata) -> Opt
   use users::get_user_by_uid;
   
   let uid = metadata.uid();
-  get_user_by_uid(uid).map(|user| user.name().to_string_lossy().into_owned())
+  match get_user_by_uid(uid) {
+    Some(user) => Some(user.name().to_string_lossy().into_owned()),
+    None => Some(format!("<deleted user {}>", uid)) // More explicit format for deleted users
+  }
 }
 
 #[cfg(target_os = "windows")]

--- a/src-tauri/src/platform.rs
+++ b/src-tauri/src/platform.rs
@@ -329,10 +329,12 @@ fn get_owner_name<P: AsRef<Path>>(_path: P, metadata: &std::fs::Metadata) -> Opt
 fn get_owner_name<P: AsRef<Path>>(_path: P, _metadata: &std::fs::Metadata) -> Option<String> {
   use std::ffi::OsString;
   use std::os::windows::ffi::{OsStringExt, OsStrExt};
-  use winapi::um::winbase::GetNamedSecurityInfoW;
-  use winapi::um::winnt::{PSID, SidTypeUser, OWNER_SECURITY_INFORMATION, SE_FILE_OBJECT};
+  use winapi::um::aclapi::GetNamedSecurityInfoW;
+  use winapi::um::winnt::{PSID, SidTypeUser, OWNER_SECURITY_INFORMATION};
+  use winapi::um::accctrl::SE_FILE_OBJECT;
   use winapi::shared::winerror::ERROR_SUCCESS;
   use winapi::um::securitybaseapi::GetSecurityDescriptorOwner;
+  use winapi::um::winbase::LocalFree;
   
   let path = _path.as_ref();
   let path_wide: Vec<u16> = path.as_os_str().encode_wide().chain(std::iter::once(0)).collect();
@@ -409,7 +411,7 @@ fn get_owner_name<P: AsRef<Path>>(_path: P, _metadata: &std::fs::Metadata) -> Op
     // Convert to OsString then to String
     let name = OsString::from_wide(&name_buf[0..(name_size - 1) as usize]);
     // Free security descriptor
-    winapi::um::securitybaseapi::LocalFree(sd as *mut _);
+    LocalFree(sd as *mut _);
     Some(name.to_string_lossy().into_owned())
   }
 }

--- a/src-tauri/src/platform.rs
+++ b/src-tauri/src/platform.rs
@@ -22,12 +22,16 @@ pub struct PathInfo {
   /// Inode and device information for detecting cycles (Unix) or file/volume ID (Windows)
   pub inode_device: Option<(u64, u64)>,
   /// File modification/access/creation times
-  #[allow(dead_code)]
   pub times: (i64, i64, i64),
   /// Whether the path is a directory
   pub is_dir: bool,
   // Whether the path is a file
   pub is_file: bool,
+  // Whether the path is a symlink
+  #[allow(dead_code)]
+  pub is_symlink: bool,
+  // The owner of the path
+  pub owner_name: Option<String>,
 }
 
 /// Get complete path information in a platform-agnostic way
@@ -49,6 +53,10 @@ pub fn get_path_info<P: AsRef<Path>>(
 
   let is_dir = metadata.is_dir();
   let is_file = metadata.is_file();
+  let is_symlink = metadata.file_type().is_symlink();
+  
+  // Get the owner name
+  let owner_name = get_owner_name(path_ref, &metadata);
 
   Some(PathInfo {
     size_bytes,
@@ -57,6 +65,8 @@ pub fn get_path_info<P: AsRef<Path>>(
     times,
     is_dir,
     is_file,
+    is_symlink,
+    owner_name,
   })
 }
 
@@ -303,5 +313,107 @@ pub fn get_space_info<P: AsRef<Path>>(path: P) -> Option<(u64, u64, u64)> {
   }
 
   // If we get here, we couldn't find the disk for the path
+  None
+}
+
+#[cfg(target_family = "unix")]
+fn get_owner_name<P: AsRef<Path>>(_path: P, metadata: &std::fs::Metadata) -> Option<String> {
+  use std::os::unix::fs::MetadataExt;
+  use users::get_user_by_uid;
+  
+  let uid = metadata.uid();
+  get_user_by_uid(uid).map(|user| user.name().to_string_lossy().into_owned())
+}
+
+#[cfg(target_os = "windows")]
+fn get_owner_name<P: AsRef<Path>>(_path: P, _metadata: &std::fs::Metadata) -> Option<String> {
+  use std::ffi::OsString;
+  use std::os::windows::ffi::OsStringExt;
+  use winapi::um::accctrl::{GetNamedSecurityInfoW, SE_FILE_OBJECT};
+  use winapi::um::aclapi::GetSecurityInfo;
+  use winapi::um::securitybaseapi::GetSecurityDescriptorOwner;
+  use winapi::um::winnt::{PSID, SidTypeUser, OWNER_SECURITY_INFORMATION};
+  use winapi::shared::winerror::ERROR_SUCCESS;
+  
+  let path = _path.as_ref();
+  let path_wide: Vec<u16> = path.as_os_str().encode_wide().chain(std::iter::once(0)).collect();
+  
+  unsafe {
+    let mut sid: PSID = std::ptr::null_mut();
+    let mut sd = std::ptr::null_mut();
+    
+    // Get security descriptor
+    let status = GetNamedSecurityInfoW(
+      path_wide.as_ptr(),
+      SE_FILE_OBJECT,
+      OWNER_SECURITY_INFORMATION,
+      &mut sid,
+      std::ptr::null_mut(),
+      std::ptr::null_mut(),
+      std::ptr::null_mut(),
+      &mut sd
+    );
+    
+    if status != ERROR_SUCCESS {
+      return None;
+    }
+    
+    // Get the SID owner
+    let mut owner: PSID = std::ptr::null_mut();
+    let mut owner_defaulted = 0;
+    if GetSecurityDescriptorOwner(sd, &mut owner, &mut owner_defaulted) == 0 {
+      return None;
+    }
+    
+    // Convert SID to name
+    let mut name_size = 0;
+    let mut domain_size = 0;
+    let mut sid_type = 0;
+    
+    // First call to get buffer sizes
+    winapi::um::sddl::LookupAccountSidW(
+      std::ptr::null(),
+      owner,
+      std::ptr::null_mut(),
+      &mut name_size,
+      std::ptr::null_mut(),
+      &mut domain_size,
+      &mut sid_type
+    );
+    
+    if name_size == 0 {
+      return None;
+    }
+    
+    // Allocate buffers
+    let mut name_buf = vec![0u16; name_size as usize];
+    let mut domain_buf = vec![0u16; domain_size as usize];
+    
+    // Second call to get actual data
+    if winapi::um::sddl::LookupAccountSidW(
+      std::ptr::null(),
+      owner,
+      name_buf.as_mut_ptr(),
+      &mut name_size,
+      domain_buf.as_mut_ptr(),
+      &mut domain_size,
+      &mut sid_type
+    ) == 0 {
+      return None;
+    }
+    
+    // Ensure we have a user
+    if sid_type != SidTypeUser {
+      return None;
+    }
+    
+    // Convert to OsString then to String
+    let name = OsString::from_wide(&name_buf[0..(name_size - 1) as usize]);
+    Some(name.to_string_lossy().into_owned())
+  }
+}
+
+#[cfg(not(any(target_family = "unix", target_os = "windows")))]
+fn get_owner_name<P: AsRef<Path>>(_path: P, _metadata: &std::fs::Metadata) -> Option<String> {
   None
 }

--- a/src/components/DirectoryScanner.tsx
+++ b/src/components/DirectoryScanner.tsx
@@ -60,6 +60,7 @@ interface FileSystemTreeNode {
   directory_count: number
   percent_of_parent: number
   last_modified_time: number
+  owner_name: string | null
   children: FileSystemTreeNode[]
 }
 
@@ -332,7 +333,7 @@ export function DirectoryScanner() {
       lastModified: new Date(
         node.last_modified_time * 1000
       ).toLocaleDateString(), // Convert Unix timestamp to Date
-      owner: "Unknown",
+      owner: node.owner_name || "Unknown",
       depth,
       backgroundColor: getColorForPercentage(),
       children: node.children.map((child) =>


### PR DESCRIPTION
- Introduced `owner_name` field in `FileSystemEntry`, `AnalyticsInfo`, and `FileSystemTreeNode` to track the owner of files and directories.
- Updated `DirectoryScanner` to display owner names, defaulting to "Unknown" if not available.
- Enhanced path information retrieval to include owner details for both Unix and Windows platforms.
- Added tests to verify owner name retrieval functionality across different operating systems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Directory tree views now include file and folder owner information, clearly displaying ownership details, defaulting to "Unknown" when not available.
	- Enhanced cross-platform support ensures accurate retrieval of file owner details on both Unix and Windows systems.
	- Added support for identifying symbolic links in file paths.
	- Introduced a fallback mechanism for platforms where owner information may not be accessible.

- **Bug Fixes**
	- Improved handling of owner information to ensure it is preserved during analytics processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->