### PR TITLE
feat: Integrate NTFS volume support for Windows file scanning

### DIFF
--- a/cursor-history/cursor_history_11.md
+++ b/cursor-history/cursor_history_11.md
@@ -1,0 +1,51 @@
+# NTFS-Reader Implementation Summary
+
+## Initial Implementation
+
+We started by implementing a Windows-specific optimization for the `calculate_size_sync` function. The goal was to use the `ntfs-reader` crate to directly read the Master File Table (MFT) on NTFS volumes rather than recursively traversing the file system.
+
+Key components:
+- Added detection for NTFS volumes on Windows
+- Implemented `calculate_size_ntfs` which reads the MFT directly
+- Maintained `calculate_size_traditional` as a fallback for non-NTFS volumes
+
+## Bug Fixing
+
+Throughout the implementation, we identified and fixed several issues:
+1. Fixed a compilation error related to missing fields in `PathInfo` initialization:
+   - Added `is_file: !file_info.is_directory`
+   - Added `is_symlink: false` (NTFS reader doesn't directly expose this)
+
+2. Fixed a major logical bug in the directory size calculation:
+   - Originally, the NTFS implementation gathered file entries but never inserted them into the analytics map
+   - Added code to populate the analytics map before attempting to calculate directory totals
+   - Implemented proper path depth sorting and parent-child relationship handling
+
+## Architecture Differences
+
+We discussed the fundamental architectural difference between the two approaches:
+
+**Traditional Method**:
+- Uses recursion to traverse directories
+- Makes system calls for each directory entry
+- Builds the directory size information bottom-up during traversal
+
+**NTFS-MFT Method**:
+- Reads the entire MFT in one operation
+- Gets all file information in a single pass
+- Filters by path prefix without traversal
+- Requires a separate post-processing step to calculate directory totals
+
+The NTFS approach provides a significant performance improvement for large directories on Windows NTFS volumes by minimizing system calls and leveraging the MFT's central database of file information.
+
+## Final Implementation
+
+The final implementation:
+1. Detects if the volume is NTFS
+2. If NTFS, reads the Master File Table
+3. Filters file entries to the target directory
+4. Adds all entries to the analytics map
+5. Calculates directory sizes by aggregating children
+6. Falls back to traditional recursive traversal for non-NTFS volumes
+
+This hybrid approach ensures optimal performance while maintaining compatibility with all file systems.

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -63,6 +63,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
+name = "array-init"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
+
+[[package]]
 name = "ashpd"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,6 +290,29 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "binread"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16598dfc8e6578e9b597d9910ba2e73618385dc9f4b1d43dd92c349d6be6418f"
+dependencies = [
+ "array-init",
+ "binread_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "binread_derive"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9672209df1714ee804b1f4d4f68c8eb2a90b1f7a07acf472f88ce198ef1fed"
+dependencies = [
+ "either",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "bitflags"
@@ -2199,6 +2228,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "ntfs-reader"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe48eb5c6c09a871da2dac2db36b49dd1f84dbf3f05e75b9d0dea6ab639ff9d6"
+dependencies = [
+ "binread",
+ "thiserror 2.0.12",
+ "time",
+ "tracing",
+ "windows 0.59.0",
 ]
 
 [[package]]
@@ -4317,6 +4359,7 @@ dependencies = [
  "dirs",
  "filesize",
  "lazy_static",
+ "ntfs-reader",
  "rayon",
  "serde",
  "serde_json",
@@ -4782,6 +4825,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f919aee0a93304be7f62e8e5027811bbba96bcb1de84d6618be56e43f8a32a1"
+dependencies = [
+ "windows-core 0.59.0",
+ "windows-targets 0.53.0",
+]
+
+[[package]]
+name = "windows"
 version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddf874e74c7a99773e62b1c671427abf01a425e77c3d3fb9fb1e4883ea934529"
@@ -4821,6 +4874,19 @@ dependencies = [
  "windows-interface 0.57.0",
  "windows-result 0.1.2",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "810ce18ed2112484b0d4e15d022e5f598113e220c53e373fb31e67e21670c1ce"
+dependencies = [
+ "windows-implement 0.59.0",
+ "windows-interface 0.59.1",
+ "windows-result 0.3.2",
+ "windows-strings",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4371,6 +4371,7 @@ dependencies = [
  "tauri-plugin-opener",
  "tauri-plugin-shell",
  "tempfile",
+ "time",
  "tokio",
  "users",
  "winapi",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -49,6 +49,7 @@ users = "0.11"
 winapi-util = "0.1"
 filesize = "0.2.0"
 winapi = { version = "0.3", features = ["winnt", "securitybaseapi", "accctrl", "aclapi", "sddl"] }
+ntfs-reader = "0.4.2"
 
 [dev-dependencies]
 tempfile = "3.10.1"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -50,6 +50,7 @@ winapi-util = "0.1"
 filesize = "0.2.0"
 winapi = { version = "0.3", features = ["winnt", "securitybaseapi", "accctrl", "aclapi", "sddl"] }
 ntfs-reader = "0.4.2"
+time = "0.3"
 
 [dev-dependencies]
 tempfile = "3.10.1"

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -5,24 +5,13 @@
   "windows": ["main"],
   "permissions": [
     "core:default",
-    "opener:default",
     "fs:default",
-    {
-      "identifier": "fs:read-dirs",
-      "allow": [
-        {
-          "path": "**"
-        }
-      ]
-    },
-    {
-      "identifier": "fs:read-files",
-      "allow": [
-        {
-          "path": "**"
-        }
-      ]
-    },
-    "dialog:default"
+    "fs:read-dirs",
+    "fs:read-files",
+    "fs:scope",
+    "fs:read-all",
+    "dialog:default",
+    "shell:default",
+    "opener:default"
   ]
 }

--- a/src-tauri/capabilities/privileged.json
+++ b/src-tauri/capabilities/privileged.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "privileged",
+  "description": "Capability for advanced disk operations",
+  "windows": ["main"],
+  "permissions": [
+    "fs:read-all",
+    "fs:scope",
+    "fs:read-dirs",
+    "fs:read-files",
+    "shell:allow-execute"
+  ]
+} 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -210,11 +210,6 @@ fn calculate_size_ntfs(
       })
   };
 
-  // Define data structures for building the tree
-
-  // Maps MFT record numbers to tree node indices
-  let id_to_index = DashMap::new();
-  
   // Tree nodes containing file/directory information
   struct TreeNode {
     record_number: u64,
@@ -233,7 +228,7 @@ fn calculate_size_ntfs(
   }
   
   // Store tree nodes
-  let nodes = Arc::new(DashMap::new());
+  let nodes: Arc<DashMap<u64, TreeNode>> = Arc::new(DashMap::new());
   
   // Create a cache for path computations
   let mut path_cache = ntfs_reader::file_info::HashMapCache::default();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -15,29 +15,8 @@ use tauri::Emitter;
 use ntfs_reader;
 
 /// Contains analytics information for a directory or file
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 struct AnalyticsInfo {
-  /// Total size in bytes
-  size_bytes: u64,
-  /// Total size in bytes on disk
-  size_allocated_bytes: u64,
-  /// Total number of entries (files and directories)
-  entry_count: u64,
-  /// Number of files
-  file_count: u64,
-  /// Number of directories
-  directory_count: u64,
-  /// Last modified time (Unix timestamp in seconds)
-  last_modified_time: u64,
-  /// Owner of the file or directory
-  owner_name: Option<String>,
-  /// Path info
-  path_info: Option<PathInfo>,
-}
-
-/// Represents size information for a file or directory
-#[derive(Clone, Debug, Serialize)]
-struct FileSystemEntry {
   /// Path to the file or directory
   path: PathBuf,
   /// Size in bytes
@@ -50,7 +29,7 @@ struct FileSystemEntry {
   file_count: u64,
   /// Number of directories
   directory_count: u64,
-  /// last modified time
+  /// Last modified time (Unix timestamp in seconds)
   last_modified_time: u64,
   /// Owner of the file or directory
   owner_name: Option<String>,
@@ -305,6 +284,7 @@ fn calculate_size_ntfs(
     processed_paths.insert(entry_path.clone());
     
     analytics_map.insert(entry_path.clone(), Arc::new(AnalyticsInfo {
+      path: entry_path.clone(),
       size_bytes,
       size_allocated_bytes,
       entry_count,
@@ -372,7 +352,7 @@ fn calculate_size_ntfs(
         } else {
           // Sequential approach for smaller directories
           for child_path in children_vec {
-            if let Some(child_analytics) = analytics_map.get(&child_path) {
+            if let Some(child_analytics) = analytics_map.get(child_path) {
               total_size += child_analytics.size_bytes;
               total_allocated += child_analytics.size_allocated_bytes;
               total_entries += child_analytics.entry_count;
@@ -438,6 +418,7 @@ fn calculate_size_traditional(
 
   // Add entry to analytics map with initial values (will be updated later for directories)
   analytics_map.insert(path.to_path_buf(), Arc::new(AnalyticsInfo {
+    path: path.to_path_buf(),
     size_bytes: path_info.size_bytes,
     size_allocated_bytes: path_info.size_allocated_bytes,
     entry_count: entry_count,
@@ -550,32 +531,17 @@ fn calculate_size_sync(
   calculate_size_traditional(path, analytics_map, target_dir_path, visited_inodes, processed_paths)
 }
 
-// This function converts the analytics map to a vector of FileSystemEntry objects
-fn analytics_map_to_entries(map: &DashMap<PathBuf, Arc<AnalyticsInfo>>) -> Vec<FileSystemEntry> {
+// This function converts the analytics map to a vector of AnalyticsInfo objects
+fn analytics_map_to_entries(map: &DashMap<PathBuf, Arc<AnalyticsInfo>>) -> Vec<AnalyticsInfo> {
   map
     .iter()
-    .map(|item| {
-      let path = item.key();
-      let analytics = item.value();
-
-      FileSystemEntry {
-        path: path.clone(),
-        size_bytes: analytics.size_bytes,
-        size_allocated_bytes: analytics.size_allocated_bytes,
-        entry_count: analytics.entry_count,
-        file_count: analytics.file_count,
-        directory_count: analytics.directory_count,
-        last_modified_time: analytics.last_modified_time as u64,
-        owner_name: analytics.owner_name.clone(),
-        path_info: analytics.path_info.clone(),
-      }
-    })
+    .map(|item| (**item.value()).clone())
     .collect()
 }
 
 // This function builds a tree from the flat list of entries with a limited depth
 fn build_tree_from_entries_with_depth(
-  entries: &[FileSystemEntry],
+  entries: &[AnalyticsInfo],
   root_path: &Path,
   max_depth: usize,
   // Whether to build a virtual directory node for the root path
@@ -593,7 +559,7 @@ fn build_tree_from_entries_with_depth(
   build_virtual_directory_node: bool,
 ) -> FileSystemTreeNode {
   // Create a map of path -> entry for quick lookups
-  let path_map: HashMap<PathBuf, &FileSystemEntry> = entries
+  let path_map: HashMap<PathBuf, &AnalyticsInfo> = entries
     .iter()
     .map(|entry| (entry.path.clone(), entry))
     .collect();
@@ -628,9 +594,9 @@ fn build_tree_from_entries_with_depth(
   // Recursive function to build the tree with depth limit
   fn build_node(
     path: &Path,
-    entry: &FileSystemEntry,
+    entry: &AnalyticsInfo,
     children_map: &HashMap<PathBuf, Vec<PathBuf>>,
-    path_map: &HashMap<PathBuf, &FileSystemEntry>,
+    path_map: &HashMap<PathBuf, &AnalyticsInfo>,
     current_depth: usize,
     max_depth: usize,
   ) -> FileSystemTreeNode {
@@ -823,7 +789,7 @@ fn build_tree_from_entries_with_depth(
 
 // This function builds a tree from prebuilt indices
 fn build_tree_from_indices(
-  entries: &[FileSystemEntry],
+  entries: &[AnalyticsInfo],
   path_map: &HashMap<PathBuf, usize>,
   children_map: &HashMap<PathBuf, Vec<usize>>,
   target_path: &Path,
@@ -842,8 +808,8 @@ fn build_tree_from_indices(
   // Recursive function to build the tree starting from the target
   fn build_node(
     path: &Path,
-    entry: &FileSystemEntry,
-    entries: &[FileSystemEntry],
+    entry: &AnalyticsInfo,
+    entries: &[AnalyticsInfo],
     children_indices: Option<&Vec<usize>>,
     current_depth: usize,
     max_depth: usize,
@@ -1072,7 +1038,7 @@ lazy_static! {
 // Structure to hold cached scan data
 struct ScanCache {
   root_path: PathBuf,
-  entries: Vec<FileSystemEntry>,
+  entries: Vec<AnalyticsInfo>,
   // Prebuilt indices for faster tree building
   path_map: HashMap<PathBuf, usize>, // Maps path to index in entries
   children_map: HashMap<PathBuf, Vec<usize>>, // Maps parent path to indices of children in entries
@@ -1204,7 +1170,7 @@ async fn scan_directory_complete(path: String, window: tauri::Window) -> std::io
 
 // Function to build indices for faster tree building
 fn build_indices(
-  entries: &[FileSystemEntry],
+  entries: &[AnalyticsInfo],
   target_dir: &Path,
 ) -> (HashMap<PathBuf, usize>, HashMap<PathBuf, Vec<usize>>) {
   // First pass: build path_map (map from path to index in entries) - parallelize this

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -147,7 +147,7 @@ fn calculate_size_sync(
   }
   
   // Fallback to traditional method if not NTFS or if NTFS reading fails
-  calculate_size_sync(path, analytics_map, target_dir_path, visited_inodes, processed_paths)
+  super::calculate_size_sync(path, analytics_map, target_dir_path, visited_inodes, processed_paths)
 }
 
 #[cfg(target_os = "windows")]
@@ -285,6 +285,8 @@ fn calculate_size_ntfs(
           owner_name: None, // We could retrieve this, but omitting for simplicity
           path_info: Some(platform::PathInfo {
             is_dir: file_info.is_directory,
+            is_file: !file_info.is_directory,
+            is_symlink: false, // NTFS reader doesn't directly expose symlink info, assuming false
             size_bytes,
             size_allocated_bytes,
             inode_device: Some(synthetic_inode),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -147,7 +147,7 @@ fn calculate_size_sync(
   }
   
   // Fallback to traditional method if not NTFS or if NTFS reading fails
-  calculate_size_original(path, analytics_map, target_dir_path, visited_inodes, processed_paths)
+  calculate_size_traditional(path, analytics_map, target_dir_path, visited_inodes, processed_paths)
 }
 
 #[cfg(target_os = "windows")]
@@ -303,17 +303,8 @@ fn calculate_size_ntfs(
   Ok(())
 }
 
-fn calculate_size_sync(
-  path: &Path,
-  analytics_map: Arc<DashMap<PathBuf, Arc<AnalyticsInfo>>>,
-  target_dir_path: &Path,
-  visited_inodes: Arc<DashSet<(u64, u64)>>,
-  processed_paths: Arc<DashSet<PathBuf>>,
-) -> std::io::Result<()> {
-  calculate_size_original(path, analytics_map, target_dir_path, visited_inodes, processed_paths)
-}
-
-fn calculate_size_original(
+#[cfg(not(target_os = "windows"))]
+fn calculate_size_traditional(
   path: &Path,
   analytics_map: Arc<DashMap<PathBuf, Arc<AnalyticsInfo>>>,
   target_dir_path: &Path,
@@ -387,7 +378,154 @@ fn calculate_size_original(
 
     // Process all children in parallel using Rayon
     entries.par_iter().for_each(|child_path| {
-      let _ = calculate_size_original(
+      let _ = calculate_size_sync(
+        child_path,
+        analytics_map.clone(),
+        target_dir_path,
+        visited_inodes.clone(),
+        processed_paths.clone(),
+      );
+    });
+
+    // Now compute the total size based on children
+    let dir_own_size = path_info.size_bytes; // Start with directory's own size
+    let dir_own_allocated_size = path_info.size_allocated_bytes; // Start with directory's own allocated size
+    let mut total_size = dir_own_size;
+    let mut total_allocated_size = dir_own_allocated_size;
+    let mut total_entries = 1; // Start with the directory itself
+    let mut total_files = 0; // Directories don't count as files
+    let mut total_dirs = 1; // Count this directory
+
+    // Sum up all children's contributions
+    for child_path in &entries {
+      // Check if the child is a direct file (not a symlink pointing to a file)
+      let child_is_file = child_path.is_file() && !child_path.is_symlink();
+
+      // Update counts for direct files first
+      if child_is_file {
+        total_files += 1;
+        total_entries += 1;
+      }
+
+      // Get analytics info for the child if it exists
+      if let Some(child_analytics) = analytics_map.get(child_path) {
+        let child_size = child_analytics.size_bytes;
+        let child_allocated_size = child_analytics.size_allocated_bytes;
+        let child_entries = child_analytics.entry_count;
+        let child_files = child_analytics.file_count;
+        let child_dirs = child_analytics.directory_count;
+
+        total_size += child_size;
+        total_allocated_size += child_allocated_size;
+
+        // For symlinks, count the entry but not as file/dir
+        if child_path.is_symlink() {
+          total_entries += 1; // Count the symlink as an entry
+        } else {
+          // For non-symlinks, add all the counts
+          if !child_is_file {
+            // Avoid double counting files we already counted
+            total_entries += child_entries;
+            total_files += child_files;
+          }
+          total_dirs += child_dirs;
+        }
+      }
+    }
+
+    // Get a mutable reference to modify the Arc<AnalyticsInfo>
+    if let Some(mut analytics_ref) = analytics_map.get_mut(&path.to_path_buf()) {
+      // Access and modify the inner AnalyticsInfo fields
+      let analytics = Arc::make_mut(&mut analytics_ref);
+
+      // Update this directory's values
+      analytics.size_bytes = total_size;
+      analytics.size_allocated_bytes = total_allocated_size;
+      analytics.entry_count = total_entries;
+      analytics.file_count = total_files;
+      analytics.directory_count = total_dirs;
+    }
+  }
+
+  Ok(())
+}
+
+
+fn calculate_size_sync(
+  path: &Path,
+  analytics_map: Arc<DashMap<PathBuf, Arc<AnalyticsInfo>>>,
+  target_dir_path: &Path,
+  visited_inodes: Arc<DashSet<(u64, u64)>>,
+  processed_paths: Arc<DashSet<PathBuf>>,
+) -> std::io::Result<()> {
+  // If we've already processed this path, skip it
+  if !processed_paths.insert(path.to_path_buf()) {
+    return Ok(());
+  }
+
+  // Get path info using our platform-agnostic function - will work for files, dirs and symlinks
+  let is_symlink = path.is_symlink();
+  let path_info = match platform::get_path_info(path, is_symlink) {
+    Some(info) => info,
+    None => return Ok(()),
+  };
+
+  // Check for cycles using device and inode numbers if available
+  // This handles both directory cycles AND symlinks properly
+  if let Some(inode_pair) = path_info.inode_device {
+    if !visited_inodes.insert(inode_pair) {
+      // We've already seen this inode, skip it
+      return Ok(());
+    }
+  }
+
+  // Count entry as file or directory, symlinks count as entries but not as files or dirs
+  let entry_count = 1; // Count this file/directory/symlink as 1 entry
+  let file_count = if path_info.is_dir || is_symlink { 0 } else { 1 };
+  let directory_count = if path_info.is_dir && !is_symlink {
+    1
+  } else {
+    0
+  };
+
+  // Add entry to analytics map with initial values (will be updated later for directories)
+  let entry_analytics = match analytics_map.entry(path.to_path_buf()) {
+    dashmap::mapref::entry::Entry::Occupied(e) => e.get().clone(),
+    dashmap::mapref::entry::Entry::Vacant(e) => {
+      let analytics = Arc::new(AnalyticsInfo {
+        size_bytes: path_info.size_bytes,
+        size_allocated_bytes: path_info.size_allocated_bytes,
+        entry_count: entry_count,
+        file_count: file_count,
+        directory_count: directory_count,
+        last_modified_time: path_info.times.0 as u64,
+        owner_name: path_info.owner_name.clone(),
+        path_info: Some(path_info.clone()),
+      });
+      e.insert(analytics.clone());
+      analytics
+    }
+  };
+
+  // For directories, process all children (but don't follow symlinks)
+  if path_info.is_dir && !is_symlink {
+    // Read directory entries
+    let entries = match std::fs::read_dir(&path) {
+      Ok(dir_entries) => {
+        let mut entry_paths = Vec::with_capacity(32); // Pre-allocate for common case
+        for entry_result in dir_entries {
+          if let Ok(entry) = entry_result {
+            entry_paths.push(entry.path());
+          }
+        }
+        entry_paths
+      }
+      Err(_) => Vec::new(),
+    };
+
+    // Process all children in parallel using Rayon
+    entries.par_iter().for_each(|child_path| {
+      let _ = calculate_size_sync(
         child_path,
         analytics_map.clone(),
         target_dir_path,
@@ -1347,7 +1485,7 @@ mod tests {
     let processed_paths = Arc::new(DashSet::new());
 
     // Run the function
-    calculate_size_original(
+    calculate_size_sync(
       path.as_path(),
       analytics_map.clone(),
       path.as_path(),
@@ -1404,7 +1542,7 @@ mod tests {
     let processed_paths = Arc::new(DashSet::new());
 
     // Run the function
-    calculate_size_original(
+    calculate_size_sync(
       path.as_path(),
       analytics_map.clone(),
       path.as_path(),
@@ -1481,7 +1619,7 @@ mod tests {
     let processed_paths = Arc::new(DashSet::new());
 
     // Run the function
-    calculate_size_original(
+    calculate_size_sync(
       path.as_path(),
       analytics_map.clone(),
       path.as_path(),
@@ -1532,7 +1670,7 @@ mod tests {
       let processed_paths = Arc::new(DashSet::new());
 
       // Use Rayon's default thread pool (parallel)
-      calculate_size_original(
+      calculate_size_sync(
         test_dir.as_path(),
         analytics_map.clone(),
         test_dir.as_path(),
@@ -1559,7 +1697,7 @@ mod tests {
         .unwrap();
 
       pool.install(|| {
-        let _ = calculate_size_original(
+        let _ = calculate_size_sync(
           test_dir.as_path(),
           analytics_map.clone(),
           test_dir.as_path(),
@@ -1612,7 +1750,7 @@ mod tests {
     let visited_inodes = Arc::new(DashSet::new());
     let processed_paths = Arc::new(DashSet::new());
 
-    calculate_size_original(
+    calculate_size_sync(
       path.as_path(),
       analytics_map.clone(),
       path.as_path(),
@@ -1673,7 +1811,7 @@ mod tests {
     let visited_inodes = Arc::new(DashSet::new());
     let processed_paths = Arc::new(DashSet::new());
 
-    calculate_size_original(
+    calculate_size_sync(
       path.as_path(),
       analytics_map.clone(),
       path.as_path(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -147,7 +147,7 @@ fn calculate_size_sync(
   }
   
   // Fallback to traditional method if not NTFS or if NTFS reading fails
-  super::calculate_size_sync(path, analytics_map, target_dir_path, visited_inodes, processed_paths)
+  calculate_size_original(path, analytics_map, target_dir_path, visited_inodes, processed_paths)
 }
 
 #[cfg(target_os = "windows")]
@@ -310,6 +310,16 @@ fn calculate_size_sync(
   visited_inodes: Arc<DashSet<(u64, u64)>>,
   processed_paths: Arc<DashSet<PathBuf>>,
 ) -> std::io::Result<()> {
+  calculate_size_original(path, analytics_map, target_dir_path, visited_inodes, processed_paths)
+}
+
+fn calculate_size_original(
+  path: &Path,
+  analytics_map: Arc<DashMap<PathBuf, Arc<AnalyticsInfo>>>,
+  target_dir_path: &Path,
+  visited_inodes: Arc<DashSet<(u64, u64)>>,
+  processed_paths: Arc<DashSet<PathBuf>>,
+) -> std::io::Result<()> {
   // If we've already processed this path, skip it
   if !processed_paths.insert(path.to_path_buf()) {
     return Ok(());
@@ -377,7 +387,7 @@ fn calculate_size_sync(
 
     // Process all children in parallel using Rayon
     entries.par_iter().for_each(|child_path| {
-      let _ = calculate_size_sync(
+      let _ = calculate_size_original(
         child_path,
         analytics_map.clone(),
         target_dir_path,
@@ -1337,7 +1347,7 @@ mod tests {
     let processed_paths = Arc::new(DashSet::new());
 
     // Run the function
-    calculate_size_sync(
+    calculate_size_original(
       path.as_path(),
       analytics_map.clone(),
       path.as_path(),
@@ -1394,7 +1404,7 @@ mod tests {
     let processed_paths = Arc::new(DashSet::new());
 
     // Run the function
-    calculate_size_sync(
+    calculate_size_original(
       path.as_path(),
       analytics_map.clone(),
       path.as_path(),
@@ -1471,7 +1481,7 @@ mod tests {
     let processed_paths = Arc::new(DashSet::new());
 
     // Run the function
-    calculate_size_sync(
+    calculate_size_original(
       path.as_path(),
       analytics_map.clone(),
       path.as_path(),
@@ -1522,7 +1532,7 @@ mod tests {
       let processed_paths = Arc::new(DashSet::new());
 
       // Use Rayon's default thread pool (parallel)
-      calculate_size_sync(
+      calculate_size_original(
         test_dir.as_path(),
         analytics_map.clone(),
         test_dir.as_path(),
@@ -1549,7 +1559,7 @@ mod tests {
         .unwrap();
 
       pool.install(|| {
-        let _ = calculate_size_sync(
+        let _ = calculate_size_original(
           test_dir.as_path(),
           analytics_map.clone(),
           test_dir.as_path(),
@@ -1602,7 +1612,7 @@ mod tests {
     let visited_inodes = Arc::new(DashSet::new());
     let processed_paths = Arc::new(DashSet::new());
 
-    calculate_size_sync(
+    calculate_size_original(
       path.as_path(),
       analytics_map.clone(),
       path.as_path(),
@@ -1663,7 +1673,7 @@ mod tests {
     let visited_inodes = Arc::new(DashSet::new());
     let processed_paths = Arc::new(DashSet::new());
 
-    calculate_size_sync(
+    calculate_size_original(
       path.as_path(),
       analytics_map.clone(),
       path.as_path(),

--- a/src-tauri/src/platform.rs
+++ b/src-tauri/src/platform.rs
@@ -467,3 +467,12 @@ fn get_owner_name<P: AsRef<Path>>(path: P, _metadata: &std::fs::Metadata) -> Opt
 fn get_owner_name<P: AsRef<Path>>(_path: P, _metadata: &std::fs::Metadata) -> Option<String> {
   None
 }
+
+/// Get the owner name for a path (convenience wrapper around get_owner_name)
+pub fn get_path_owner<P: AsRef<Path>>(path: P) -> Option<String> {
+  if let Ok(metadata) = std::fs::metadata(path.as_ref()) {
+    get_owner_name(path, &metadata)
+  } else {
+    None
+  }
+}

--- a/src-tauri/src/platform.rs
+++ b/src-tauri/src/platform.rs
@@ -374,6 +374,7 @@ fn get_owner_name<P: AsRef<Path>>(path: P, _metadata: &std::fs::Metadata) -> Opt
   use std::os::windows::ffi::{OsStrExt, OsStringExt};
   use winapi::ctypes::c_void;
   use winapi::shared::winerror::ERROR_SUCCESS;
+  use winapi::shared::sddl;
   use winapi::um::accctrl::SE_FILE_OBJECT;
   use winapi::um::aclapi::GetNamedSecurityInfoW;
   use winapi::um::securitybaseapi::GetSecurityDescriptorOwner;
@@ -435,7 +436,7 @@ fn get_owner_name<P: AsRef<Path>>(path: P, _metadata: &std::fs::Metadata) -> Opt
 
     // Convert SID to string for cache key
     let mut sid_string_ptr: winapi::um::winnt::LPWSTR = std::ptr::null_mut();
-    if winapi::um::sddl::ConvertSidToStringSidW(owner, &mut sid_string_ptr) == 0 {
+    if sddl::ConvertSidToStringSidW(owner, &mut sid_string_ptr) == 0 {
       eprintln!("ConvertSidToStringSidW failed");
       return None;
     }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,6 +21,11 @@
       "csp": null
     }
   },
+  "plugins": {
+    "shell": {
+      "open": true
+    }
+  },
   "bundle": {
     "active": true,
     "targets": "all",


### PR DESCRIPTION
- Added support for NTFS volume detection and processing in `calculate_size_sync` and `calculate_size_ntfs` functions.
- Introduced the `ntfs-reader` crate to facilitate reading NTFS file system structures.
- Enhanced analytics gathering by leveraging NTFS-specific features for improved file size calculations and metadata retrieval.
- Updated `Cargo.toml` and `Cargo.lock` to include new dependencies for NTFS handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced Windows directory size calculation with improved NTFS support for more accurate performance.
	- New functionality to calculate directory sizes specifically for NTFS volumes.
	- Added dependencies for NTFS functionality and time management in the application.
	- Introduced a convenience method to retrieve file owner names more easily.
	- Added a new configuration for shell-related functionalities.
	- Defined a new capability for advanced disk operations.
- **Bug Fixes**
	- Resolved compilation errors and logical bugs in directory size calculation.
	- Improved caching for owner name lookups to enhance performance.
- **Chores**
	- Streamlined permissions format in capability definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->