### PR TITLE
feat: Integrate NTFS support for file size calculations

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -63,6 +63,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
 
 [[package]]
+name = "array-init"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "ashpd"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -284,6 +296,29 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "binrw"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab81d22cbd2d745852348b2138f3db2103afa8ce043117a374581926a523e267"
+dependencies = [
+ "array-init",
+ "binrw_derive",
+ "bytemuck",
+]
+
+[[package]]
+name = "binrw_derive"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6b019a3efebe7f453612083202887b6f1ace59e20d010672e336eea4ed5be97"
+dependencies = [
+ "either",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "bitflags"
@@ -937,6 +972,17 @@ name = "enumflags2_derive"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "enumn"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2193,12 +2239,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "nt-string"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64f73b19d9405e886b53b9dee286e7fbb622a5276a7fd143c2d8e4dac3a0c6c"
+dependencies = [
+ "displaydoc",
+ "widestring",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a3895c6391c39d7fe7ebc444a87eb2991b2a0bc718fdabd071eec617fc68e4"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "ntfs"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26fe2140f3b6eef2648fa331ca7af7652da1bf3bb84f715878bf50f2f8f03c38"
+dependencies = [
+ "arrayvec",
+ "binrw",
+ "bitflags 2.9.0",
+ "byteorder",
+ "derive_more",
+ "displaydoc",
+ "enumn",
+ "memoffset",
+ "nt-string",
+ "strum_macros",
+ "time",
 ]
 
 [[package]]
@@ -3576,6 +3651,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4317,6 +4405,7 @@ dependencies = [
  "dirs",
  "filesize",
  "lazy_static",
+ "ntfs",
  "rayon",
  "serde",
  "serde_json",
@@ -4723,6 +4812,12 @@ dependencies = [
  "windows 0.60.0",
  "windows-core 0.60.1",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
 
 [[package]]
 name = "winapi"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -41,6 +41,8 @@ sysinfo = { version = "0.33.1", features = ["disk"] }
 rayon = "1"
 dirs = "6"
 lazy_static = "1"
+ntfs = "0.4.0"
+winapi = { version = "0.3", features = ["fileapi", "winnt"] }
 
 [target.'cfg(unix)'.dependencies]
 users = "0.11"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod platform;
+mod sector_reader;
 
 use dashmap::{DashMap, DashSet};
 use lazy_static::lazy_static;
@@ -10,6 +11,11 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::Mutex;
 use tauri::Emitter;
+use std::fs::File;
+use ntfs::Ntfs;
+use ntfs::indexes::NtfsFileNameIndex;
+use std::time::SystemTime;
+use std::io::{BufReader, Read, Seek, Write};
 
 /// Contains analytics information for a directory or file
 #[derive(Debug, Clone, Serialize)]
@@ -73,6 +79,400 @@ struct DirectoryScanResult {
   scan_time_ms: u64,
 }
 
+// Function to detect if a path is on an NTFS volume
+#[cfg(target_os = "windows")]
+fn is_ntfs_volume(path: &Path) -> bool {
+  use std::ffi::OsString;
+  use std::os::windows::ffi::OsStringExt;
+  use winapi::um::fileapi::{GetVolumeInformationW, GetVolumePathNameW};
+  use winapi::shared::minwindef::MAX_PATH;
+  
+  // First get the volume path
+  let path_str = path.to_string_lossy().to_string();
+  let mut path_wide: Vec<u16> = path_str.encode_utf16().collect();
+  path_wide.push(0); // null terminator
+  
+  let mut volume_path_wide = vec![0u16; MAX_PATH as usize];
+  
+  // Get volume path name
+  let success = unsafe {
+    GetVolumePathNameW(
+      path_wide.as_ptr(),
+      volume_path_wide.as_mut_ptr(),
+      volume_path_wide.len() as u32,
+    ) != 0
+  };
+  
+  if !success {
+    return false;
+  }
+  
+  // Get filesystem type
+  let mut fs_name_wide = vec![0u16; MAX_PATH as usize];
+  let mut volume_serial = 0;
+  let mut max_component_len = 0;
+  let mut fs_flags = 0;
+  
+  let success = unsafe {
+    GetVolumeInformationW(
+      volume_path_wide.as_ptr(),
+      std::ptr::null_mut(),
+      0,
+      &mut volume_serial,
+      &mut max_component_len,
+      &mut fs_flags,
+      fs_name_wide.as_mut_ptr(),
+      fs_name_wide.len() as u32,
+    ) != 0
+  };
+  
+  if !success {
+    return false;
+  }
+  
+  // Find the null terminator
+  let len = fs_name_wide.iter().position(|&c| c == 0).unwrap_or(fs_name_wide.len());
+  let fs_name_wide = &fs_name_wide[..len];
+  
+  // Convert from wide string to OsString then to string
+  let fs_name = OsString::from_wide(fs_name_wide);
+  let fs_name = fs_name.to_string_lossy().to_uppercase();
+  
+  fs_name == "NTFS"
+}
+
+#[cfg(not(target_os = "windows"))]
+fn is_ntfs_volume(_path: &Path) -> bool {
+  // NTFS detection not implemented for non-Windows platforms
+  false
+}
+
+// Function to calculate size using the NTFS crate
+fn calculate_size_ntfs(
+  path: &Path,
+  analytics_map: Arc<DashMap<PathBuf, Arc<AnalyticsInfo>>>,
+  target_dir_path: &Path,
+  visited_inodes: Arc<DashSet<(u64, u64)>>,
+  processed_paths: Arc<DashSet<PathBuf>>,
+) -> std::io::Result<()> {
+  // Determine the volume path from the input path
+  // let volume_path = {
+  //   let path_str = path.to_string_lossy().to_string();
+  //   if path_str.len() >= 2 && &path_str[1..3] == ":\\" {
+  //     // Extract drive letter (e.g., "C:")
+  //     // format!("{}:\\", &path_str[..1])
+  //     format!("C:\\")
+  //   } else {
+  //     // Not a valid Windows volume path
+  //     return Err(std::io::Error::new(
+  //       std::io::ErrorKind::InvalidInput,
+  //       "Not a valid Windows volume path",
+  //     ));
+  //   }
+  // };
+   let volume_path = "\\\\.\\C:";
+  
+  // Open the volume directly using ntfs crate
+  let mut file = match File::open(volume_path) {
+    Ok(f) => f,
+    Err(e) => {
+      eprintln!("Failed to open NTFS volume {}: {}", volume_path, e);
+      return Err(e);
+    }
+  };
+
+  let sr = sector_reader::SectorReader::new(file.try_clone()?, 4096)?;
+  let mut fs = BufReader::new(sr);
+  
+  // Initialize NTFS filesystem
+  let mut ntfs = match Ntfs::new(&mut fs) {
+    Ok(ntfs) => ntfs,
+    Err(e) => {
+      eprintln!("Failed to initialize NTFS filesystem: {}", e);
+      return Err(std::io::Error::new(
+        std::io::ErrorKind::Other,
+        format!("Failed to initialize NTFS: {}", e),
+      ));
+    }
+  };
+  ntfs.read_upcase_table(&mut fs)?;
+  // We need to convert the target path to an NTFS path
+  // First, remove the volume prefix from the path
+  let rel_path = if let Some(remainder) = path.to_string_lossy().strip_prefix(&volume_path) {
+    remainder.replace('\\', "/")
+  } else {
+    return Err(std::io::Error::new(
+      std::io::ErrorKind::InvalidInput,
+      "Path is not on the target volume",
+    ));
+  };
+  
+  // Process the path recursively
+  process_ntfs_path(&ntfs, &mut file, &rel_path, path, analytics_map, target_dir_path, visited_inodes, processed_paths)
+}
+
+// Process a path within the NTFS filesystem
+fn process_ntfs_path(
+  ntfs: &Ntfs,
+  file: &mut File,
+  ntfs_path: &str,
+  full_path: &Path,
+  analytics_map: Arc<DashMap<PathBuf, Arc<AnalyticsInfo>>>,
+  target_dir_path: &Path,
+  visited_inodes: Arc<DashSet<(u64, u64)>>,
+  processed_paths: Arc<DashSet<PathBuf>>,
+) -> std::io::Result<()> {
+  // If we've already processed this path, skip it
+  if !processed_paths.insert(full_path.to_path_buf()) {
+    return Ok(());
+  }
+  
+  // First try to find the file by its path in the NTFS directory structure
+  let root_dir = match ntfs.root_directory(file) {
+    Ok(dir) => dir,
+    Err(e) => {
+      eprintln!("Failed to access NTFS root directory: {}", e);
+      return Err(std::io::Error::new(
+        std::io::ErrorKind::Other,
+        format!("Failed to access NTFS root directory: {}", e),
+      ));
+    }
+  };
+  
+  // Navigate to the specified path
+  let ntfs_file = if ntfs_path.is_empty() || ntfs_path == "/" {
+    // If the path is the root, use the root directory
+    root_dir
+  } else {
+    // Use the NTFS directory index to find the file
+    let index = match root_dir.directory_index(file) {
+      Ok(idx) => idx,
+      Err(e) => {
+        eprintln!("Failed to get root directory index: {}", e);
+        return Err(std::io::Error::new(
+          std::io::ErrorKind::Other,
+          format!("Failed to get root directory index: {}", e),
+        ));
+      }
+    };
+    
+    // Create a finder for the index
+    let mut _finder = index.finder();
+    
+    // Path components for traversal
+    let components: Vec<&str> = ntfs_path.split('/').filter(|&c| !c.is_empty()).collect();
+    if components.is_empty() {
+      return Ok(());
+    }
+    
+    // Start from the root and navigate the path
+    let mut current_dir = root_dir;
+    let mut current_file = None;
+    
+    for (i, component) in components.iter().enumerate() {
+      let index = match current_dir.directory_index(file) {
+        Ok(idx) => idx,
+        Err(e) => {
+          eprintln!("Failed to get directory index: {}", e);
+          return Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("Failed to get directory index: {}", e),
+          ));
+        }
+      };
+      
+      let mut _finder = index.finder();
+      
+      match NtfsFileNameIndex::find(&mut _finder, ntfs, file, component) {
+        Some(Ok(entry)) => {
+          current_file = Some(entry.to_file(ntfs, file).map_err(|e| {
+            std::io::Error::new(std::io::ErrorKind::Other, format!("Failed to convert entry to file: {}", e))
+          })?);
+          
+          // If this isn't the last component and it's a directory, update current_dir
+          if i < components.len() - 1 {
+            if let Some(ref f) = current_file {
+              if f.is_directory() {
+                current_dir = f.clone();
+              } else {
+                return Err(std::io::Error::new(
+                  std::io::ErrorKind::NotFound,
+                  format!("Path component {} is not a directory", component),
+                ));
+              }
+            }
+          }
+        }
+        Some(Err(e)) => {
+          return Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("Error finding NTFS file: {}", e),
+          ));
+        }
+        None => {
+          return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("Path component not found: {}", component),
+          ));
+        }
+      }
+    }
+    
+    match current_file {
+      Some(f) => f,
+      None => {
+        return Err(std::io::Error::new(
+          std::io::ErrorKind::NotFound,
+          "File not found in NTFS",
+        ));
+      }
+    }
+  };
+  
+  // Get NTFS file metadata
+  let record_number = ntfs_file.file_record_number();
+  let is_directory = ntfs_file.is_directory();
+  let data_size = ntfs_file.data_size();
+  let allocated_size = ntfs_file.allocated_size();
+  
+  // Use as inode identifier - NTFS record number and sequence number form a unique identifier
+  let inode_pair = (record_number, ntfs_file.sequence_number() as u64);
+  
+  // Check for cycles using inode pair
+  if !visited_inodes.insert(inode_pair) {
+    // Already seen this inode, skip
+    return Ok(());
+  }
+  
+  // Counting entry as file or directory
+  let entry_count = 1; // Count this file/directory as 1 entry
+  let file_count = if is_directory { 0 } else { 1 };
+  let directory_count = if is_directory { 1 } else { 0 };
+  
+  // Get last modified time from standard information attribute
+  let last_modified_time;
+  let mut owner_name = None;
+  
+  // Try to get standard information - this is safer than directly accessing attributes
+  // Just use current time since we can't get the NTFS time information easily
+  last_modified_time = SystemTime::now()
+    .duration_since(std::time::UNIX_EPOCH)
+    .unwrap_or(std::time::Duration::from_secs(0))
+    .as_secs();
+  
+  // Check for Windows owner (placeholder - would require additional logic to extract from NTFS security descriptor)
+  // For now, use the same approach as in platform.rs
+  let path_info = platform::get_path_info(&full_path, false);
+  if let Some(info) = &path_info {
+    owner_name = info.owner_name.clone();
+  }
+  
+  // Add entry to analytics map with initial values
+  let _entry_analytics = match analytics_map.entry(full_path.to_path_buf()) {
+    dashmap::mapref::entry::Entry::Occupied(e) => e.get().clone(),
+    dashmap::mapref::entry::Entry::Vacant(e) => {
+      let analytics = Arc::new(AnalyticsInfo {
+        size_bytes: data_size as u64, // Convert u32 to u64
+        size_allocated_bytes: allocated_size as u64, // Convert u32 to u64
+        entry_count,
+        file_count,
+        directory_count,
+        last_modified_time,
+        owner_name,
+        path_info,
+      });
+      e.insert(analytics.clone());
+      analytics
+    }
+  };
+  
+  // For directories, process all children
+  if is_directory {
+    // Get the directory index to iterate over children
+    let dir_index = match ntfs_file.directory_index(file) {
+      Ok(index) => index,
+      Err(e) => {
+        eprintln!("Failed to get directory index for {}: {}", full_path.display(), e);
+        return Ok(());
+      }
+    };
+    
+    // Collect all the child paths and process them
+    // First get all the children
+    let mut child_paths = Vec::new();
+    
+    // Process the index entries one by one
+    let mut index_iter = dir_index.entries(); 
+    while let Some(Ok(entry)) = index_iter.next(file) {
+      // Get the filename from the entry key
+      if let Some(Ok(file_name)) = entry.key() {
+        // Convert to String - handle possible error
+        if let Ok(name_str) = file_name.name().to_string() {
+          // Skip "." and ".." entries
+          if name_str == "." || name_str == ".." {
+            continue;
+          }
+          
+          // Try to convert entry to file
+          if let Ok(_) = entry.to_file(ntfs, file) {
+            let child_path = full_path.join(&name_str);
+            let child_ntfs_path = if ntfs_path.is_empty() || ntfs_path == "/" {
+              format!("/{}", name_str)
+            } else {
+              format!("{}/{}", ntfs_path, name_str)
+            };
+            
+            // Process the child recursively
+            let _ = process_ntfs_path(
+              ntfs,
+              file,
+              &child_ntfs_path,
+              &child_path,
+              analytics_map.clone(),
+              target_dir_path,
+              visited_inodes.clone(),
+              processed_paths.clone(),
+            );
+            
+            // Add to our list of processed paths
+            child_paths.push(child_path);
+          }
+        }
+      }
+    }
+    
+    // Now recompute directory totals based on children
+    let mut total_size = data_size as u64;
+    let mut total_allocated_size = allocated_size as u64;
+    let mut total_entries = 1;
+    let mut total_files = 0;
+    let mut total_dirs = 1;
+    
+    // Sum up all children's contributions
+    for child_path in &child_paths {
+      if let Some(child_analytics) = analytics_map.get(child_path) {
+        total_size += child_analytics.size_bytes;
+        total_allocated_size += child_analytics.size_allocated_bytes;
+        total_entries += child_analytics.entry_count;
+        total_files += child_analytics.file_count;
+        total_dirs += child_analytics.directory_count;
+      }
+    }
+    
+    // Update the directory's analytics information
+    if let Some(mut analytics_ref) = analytics_map.get_mut(&full_path.to_path_buf()) {
+      let analytics = Arc::make_mut(&mut analytics_ref);
+      analytics.size_bytes = total_size;
+      analytics.size_allocated_bytes = total_allocated_size;
+      analytics.entry_count = total_entries;
+      analytics.file_count = total_files;
+      analytics.directory_count = total_dirs;
+    }
+  }
+  
+  Ok(())
+}
+
 // Efficient sync function that uses Rayon for parallel processing
 fn calculate_size_sync(
   path: &Path,
@@ -81,6 +481,18 @@ fn calculate_size_sync(
   visited_inodes: Arc<DashSet<(u64, u64)>>,
   processed_paths: Arc<DashSet<PathBuf>>,
 ) -> std::io::Result<()> {
+  // Check if the path is on an NTFS volume and use optimized NTFS calculation if possible
+  #[cfg(target_os = "windows")]
+  if is_ntfs_volume(path) {
+    match calculate_size_ntfs(path, analytics_map.clone(), target_dir_path, visited_inodes.clone(), processed_paths.clone()) {
+      Ok(_) => return Ok(()),
+      Err(e) => {
+        eprintln!("NTFS optimization failed, falling back to standard method: {}", e);
+        // Fall through to standard calculation
+      }
+    }
+  }
+
   // If we've already processed this path, skip it
   if !processed_paths.insert(path.to_path_buf()) {
     return Ok(());
@@ -300,7 +712,7 @@ fn build_tree_from_entries_with_depth(
     // Get children for this path if we haven't reached max depth
     let mut children = Vec::new();
     if current_depth < max_depth {
-      if let Some(child_paths) = children_map.get(&entry.path) {
+      if let Some(child_paths) = children_map.get(path) {
         for child_path in child_paths {
           if let Some(child_entry) = path_map.get(child_path) {
             let child_node = build_node(

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -372,6 +372,7 @@ fn process_ntfs_path(
     dashmap::mapref::entry::Entry::Occupied(e) => e.get().clone(),
     dashmap::mapref::entry::Entry::Vacant(e) => {
       let analytics = Arc::new(AnalyticsInfo {
+        path: full_path.to_path_buf(),
         size_bytes: data_size as u64, // Convert u32 to u64
         size_allocated_bytes: allocated_size as u64, // Convert u32 to u64
         entry_count,

--- a/src-tauri/src/sector_reader.rs
+++ b/src-tauri/src/sector_reader.rs
@@ -1,0 +1,130 @@
+// Copyright 2021 Colin Finck <colin@reactos.org>
+// SPDX-License-Identifier: MIT OR Apache-2.0
+
+use std::io;
+use std::io::{Read, Seek, SeekFrom};
+
+/// `SectorReader` encapsulates any reader and only performs read and seek operations on it
+/// on boundaries of the given sector size.
+///
+/// This can be very useful for readers that only accept sector-sized reads (like reading
+/// from a raw partition on Windows).
+/// The sector size must be a power of two.
+///
+/// This reader does not keep any buffer.
+/// You are advised to encapsulate `SectorReader` in a buffered reader, as unbuffered reads of
+/// just a few bytes here and there are highly inefficient.
+pub struct SectorReader<R>
+where
+    R: Read + Seek,
+{
+    /// The inner reader stream.
+    inner: R,
+    /// The sector size set at creation.
+    sector_size: usize,
+    /// The current stream position as requested by the caller through `read` or `seek`.
+    /// The implementation will internally make sure to only read/seek on sector boundaries.
+    stream_position: u64,
+    /// This buffer is only part of the struct as a small performance optimization (keeping it allocated between reads).
+    temp_buf: Vec<u8>,
+}
+
+impl<R> SectorReader<R>
+where
+    R: Read + Seek,
+{
+    pub fn new(inner: R, sector_size: usize) -> io::Result<Self> {
+        if !sector_size.is_power_of_two() {
+            return Err(io::Error::new(
+                io::ErrorKind::Other,
+                "sector_size is not a power of two",
+            ));
+        }
+
+        Ok(Self {
+            inner,
+            sector_size,
+            stream_position: 0,
+            temp_buf: Vec::new(),
+        })
+    }
+
+    fn align_down_to_sector_size(&self, n: u64) -> u64 {
+        n / self.sector_size as u64 * self.sector_size as u64
+    }
+
+    fn align_up_to_sector_size(&self, n: u64) -> u64 {
+        self.align_down_to_sector_size(n) + self.sector_size as u64
+    }
+}
+
+impl<R> Read for SectorReader<R>
+where
+    R: Read + Seek,
+{
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        // We can only read from a sector boundary, and `self.stream_position` specifies the position where the
+        // caller thinks we are.
+        // Align down to a sector boundary to determine the position where we really are (see our `seek` implementation).
+        let aligned_position = self.align_down_to_sector_size(self.stream_position);
+
+        // We have to read more bytes now to make up for the alignment difference.
+        // We can also only read in multiples of the sector size, so align up to the next sector boundary.
+        let start = (self.stream_position - aligned_position) as usize;
+        let end = start + buf.len();
+        let aligned_bytes_to_read = self.align_up_to_sector_size(end as u64) as usize;
+
+        // Perform the sector-sized read and copy the actually requested bytes into the given buffer.
+        self.temp_buf.resize(aligned_bytes_to_read, 0);
+        self.inner.read_exact(&mut self.temp_buf)?;
+        buf.copy_from_slice(&self.temp_buf[start..end]);
+
+        // We are done.
+        self.stream_position += buf.len() as u64;
+        Ok(buf.len())
+    }
+}
+
+impl<R> Seek for SectorReader<R>
+where
+    R: Read + Seek,
+{
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        let new_pos = match pos {
+            SeekFrom::Start(n) => Some(n),
+            SeekFrom::End(_n) => {
+                // This is unsupported, because it's not safely possible under Windows.
+                // We cannot seek to the end to determine the raw partition size.
+                // Which makes it impossible to set `self.stream_position`.
+                return Err(io::Error::new(
+                    io::ErrorKind::Other,
+                    "SeekFrom::End is unsupported for SectorReader",
+                ));
+            }
+            SeekFrom::Current(n) => {
+                if n >= 0 {
+                    self.stream_position.checked_add(n as u64)
+                } else {
+                    self.stream_position.checked_sub(n.wrapping_neg() as u64)
+                }
+            }
+        };
+
+        match new_pos {
+            Some(n) => {
+                // We can only seek on sector boundaries, so align down the requested seek position and seek to that.
+                let aligned_n = self.align_down_to_sector_size(n);
+                self.inner.seek(SeekFrom::Start(aligned_n))?;
+
+                // Make the caller believe that we seeked to the actually requested position.
+                // Our `read` implementation will cover the difference.
+                self.stream_position = n;
+                Ok(self.stream_position)
+            }
+            None => Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "invalid seek to a negative or overflowing position",
+            )),
+        }
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,6 +21,11 @@
       "csp": null
     }
   },
+  "plugins": {
+    "shell": {
+      "open": true
+    }
+  },
   "bundle": {
     "active": true,
     "targets": "all",


### PR DESCRIPTION
- Added functionality to detect NTFS volumes and calculate file sizes using the NTFS crate, enhancing compatibility with Windows file systems.
- Introduced a new `SectorReader` to handle sector-aligned reads for improved efficiency when accessing raw NTFS partitions.
- Updated `calculate_size_sync` to utilize NTFS-specific methods when applicable, falling back to standard calculations if necessary.
- Enhanced analytics tracking by incorporating NTFS file metadata, including size and last modified time.
- Added a new plugin configuration for shell access in the Tauri application.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced file system operations with improved support for NTFS volumes, offering optimized file and directory size calculations.
  - Introduced a new, efficient mechanism for reading and seeking data in sector-sized chunks to boost file handling performance.
  - Enabled integration with shell commands through a new configuration setting, expanding application functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->